### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ script:
 matrix:
   allow_failures:
     - go: tip
+    - go: "1.7.x"
+    - go: "1.8.x"
+    - go: "1.9.x"
+    - go: "1.10.x"
   include:
   - go: "1.7.x"
     script:  go test -v ./...
@@ -34,6 +38,30 @@ matrix:
     script: go test -v -mod=vendor ./...
   - go: "tip"
     script: go test -v -mod=vendor ./...
-
+#poweron support added 
+  - go: "1.7.x"
+    arch : ppc64le
+    script:  go test -v ./...
+  - go: "1.8.x"
+    arch : ppc64le
+    script:  go test -v ./...
+  - go: "1.9.x"
+    arch : ppc64le
+    script:  go test -v ./...
+  - go: "1.10.x"
+    arch : ppc64le
+    script:  go test -v ./...
+  - go: "1.11.x"
+    arch : ppc64le
+    script: go test -v -mod=vendor ./...
+  - go: "1.12.x"
+    arch : ppc64le
+    script: go test -v -mod=vendor ./...
+  - go: "1.13.x"
+    arch : ppc64le
+    script: go test -v -mod=vendor ./...
+  - go: "tip"
+    arch : ppc64le
+    script: go test -v -mod=vendor ./...
 git:
   depth: 10


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,For more info tag @gerrith3.

We typically build applications for customers and ISVs, and while we don't use this package directly, we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model.

